### PR TITLE
adding validation for api/form

### DIFF
--- a/formValidator.js
+++ b/formValidator.js
@@ -1,0 +1,11 @@
+const { celebrate, Joi, Segments } = require('celebrate');
+
+const validateForm = celebrate({
+  [Segments.BODY]: Joi.object().keys({
+    name: Joi.string().required(),
+    contact: Joi.string().required(),
+    message: Joi.string().required(),
+  }),
+});
+
+module.exports = validateForm;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 const express = require('express')
 const bodyParser = require('body-parser')
+const validateForm = require('./formValidator');
+const { errors } = require('celebrate');
 const app = express()
 const port = process.env.PORT || 5000
 
@@ -26,7 +28,7 @@ app.get('/', (req, res) => {
   res.send('Hello World!')
 })
 
-app.post('/api/form', jsonParser, function (req, res) {
+app.post('/api/form', jsonParser, validateForm, function (req, res) {
   const { name, contact, message } = req.body
   const text = `CONTACT FORM \nName: ${name} \nContact: ${contact} \nMessage: ${message}`
   bot.sendMessage(chatId, text).then(() => {
@@ -34,6 +36,8 @@ app.post('/api/form', jsonParser, function (req, res) {
       res.sendStatus(200);
     });
 })
+
+app.use(errors());
 
 app.listen(port, () => {
   console.log(`App listening on port ${port}`)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "vczb <viniciuszucatti@gmail.com>",
   "license": "ISC",
   "dependencies": {
+    "celebrate": "^15.0.3",
     "express": "^4.17.2",
     "node-telegram-bot-api": "^0.56.0"
   }


### PR DESCRIPTION
@vczb 

### Issue: #3

I added [celebrate ](https://github.com/arb/celebrate#readme) for validation on 'api/form'. 

Some test responses are set out below for:

- request body is valid
- request body has an incorrect property
- request body has a missing property
- value in request body is empty

when req.body is correct {name: "Some Person", contact: "persona@gmail.com", message: "This is a message"}
![image](https://github.com/mr3saru/telegram-contact-form/assets/57863817/ccb0f174-f3b1-4d10-b375-c638ac5b7c12)

when req.body has incorrect property **names** {names: "Some Person", contact: "persona@gmail.com", message: "This is a message"}
![image](https://github.com/mr3saru/telegram-contact-form/assets/57863817/f190181b-4348-4fa2-b720-66d331ecfeea)
 
when req.body is missing a property **contact** {names: "Some Person", message: "This is a message"}
![image](https://github.com/mr3saru/telegram-contact-form/assets/57863817/4caa2f7e-767c-4379-a26e-97e97a1cee42)

when req.body has an empty value for **message**  {names: "Some Person", contact: "persona@gmail.com", message: ""}
![image](https://github.com/mr3saru/telegram-contact-form/assets/57863817/e9f26e50-1dd0-4da5-a138-1ae09cd577c6)
 


